### PR TITLE
Potential fix for code scanning alert no. 25: Unsigned difference expression compared to zero

### DIFF
--- a/src/mgmt/rpc/server/IPCSocketServer.cc
+++ b/src/mgmt/rpc/server/IPCSocketServer.cc
@@ -413,7 +413,7 @@ IPCSocketServer::Client::read_all(Buffer &bw) const
       return {false, swoc::bwprint(buff, "Peer disconnected. EOF")};
     }
     bw.save(ret);
-    if (_max_req_size - bw.stored() > 0) { // we can still read more.
+    if (bw.stored() < _max_req_size) { // we can still read more.
       using namespace std::chrono_literals;
       if (!this->poll_for_data(1ms)) {
         return {true, buff};


### PR DESCRIPTION
Potential fix for [https://github.com/codeallthethingsbreak/trafficserver/security/code-scanning/25](https://github.com/codeallthethingsbreak/trafficserver/security/code-scanning/25)

To fix the issue, we need to ensure that the comparison logic does not rely on unsigned subtraction, which can underflow. Instead, we can directly compare `bw.stored()` with `_max_req_size` to determine if there is still space available in the buffer. Specifically:
- Replace `_max_req_size - bw.stored() > 0` with `bw.stored() < _max_req_size`.
- This avoids the unsigned subtraction entirely and achieves the same logical result in a safer and clearer manner.

The fix will be applied to line 416 in the file `src/mgmt/rpc/server/IPCSocketServer.cc`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
